### PR TITLE
Changed the way that the NotificationExpanded is populated

### DIFF
--- a/blomsterLandet/src/components/notifications/NotificationExpanded.js
+++ b/blomsterLandet/src/components/notifications/NotificationExpanded.js
@@ -9,18 +9,19 @@ import React, { Component } from 'react';
 import { Text, Image, Modal, Button, View } from 'react-native';
 import { Card, CardSection } from '../common/index';
 
-
 class NotificationExpanded extends Component {
     constructor(props) {
         super(props);
         this.state = {
             modalVisible: false,
+            imagePlaceHolder: require('./../../resources/images/tomat.jpg') //imagePlaceHolder has to be fixed to be dynamic
         };
     }
 
     componentWillReceiveProps(nextProps) {
         if (nextProps.modalVisible !== this.state.modalVisible) {
           this.setState({ modalVisible: nextProps.modalVisible });
+          this.setModalVisible(nextProps.modalVisible);
         }
       }
     
@@ -36,10 +37,6 @@ class NotificationExpanded extends Component {
          } = styles;
          return (
             <View>
-                <Button 
-                    onPress={() => this.setModalVisible(!this.state.modalVisible)} 
-                    title="Notis"
-                />
                 {/*Modal is the Component that becomes visible when the state is set to visible*/}
                 <Modal
                     animationType="slide"
@@ -51,7 +48,7 @@ class NotificationExpanded extends Component {
                     <CardSection>
                         <Image
                             style={imageStyle}
-                            source={this.props.imageSource}
+                            source={this.state.imagePlaceHolder}
                         />
                         <View style={buttonContainer}>
                             <Button 
@@ -82,7 +79,7 @@ const styles = {
     imageStyle: {
         marginTop: 10,
         height: 180, 
-        width: null,
+        width: 200,
         flex: 1
     },
     buttonContainer: {

--- a/blomsterLandet/src/components/notifications/NotificationListItem.js
+++ b/blomsterLandet/src/components/notifications/NotificationListItem.js
@@ -2,12 +2,12 @@ import React from 'react';
 import { Text, TouchableOpacity } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 
-const NotificationListItem = ({ pressed, title }) => {
+const NotificationListItem = ({ pressed, notification }) => {
     const { itemStyle, textStyle, arrowStyle } = styles;
     return (
-        <TouchableOpacity onPress={() => (pressed(title))} style={itemStyle}>
+        <TouchableOpacity onPress={() => (pressed(notification))} style={itemStyle}>
             <Text style={textStyle}>
-                {title}
+                {notification.title}
             </Text>
             <Icon name="chevron-right" style={arrowStyle} />
         </TouchableOpacity>

--- a/blomsterLandet/src/screens/NotificationScreen.js
+++ b/blomsterLandet/src/screens/NotificationScreen.js
@@ -7,10 +7,10 @@ class NotificationScreen extends React.Component {
 
     state = {
         notificationExpanded: false,
-        notifications: [{ title: 'Tomat', description: 'Dags att odla tomater!' }, { title: 'Jord', description: 'Asdf!' }],
+        notifications: [{ title: 'Tomat', description: 'Dags att odla tomater!' }, { title: 'Jord', description: 'Hej' }],
         notificationMap: [],
         expandedTitle: '',
-        expandedDescription: ''
+        expandedDescription: '',
     };
 
     componentWillMount() {
@@ -54,7 +54,7 @@ class NotificationScreen extends React.Component {
                 <NotificationExpanded
                     title={this.state.expandedTitle}
                     description={this.state.expandedDescription}
-                    modalvisible={this.notificationExpanded}
+                    modalvisible={this.state.notificationExpanded}
                 />
                 <ScrollView>
                     {this.state.notificationMap}

--- a/blomsterLandet/src/screens/NotificationScreen.js
+++ b/blomsterLandet/src/screens/NotificationScreen.js
@@ -7,7 +7,7 @@ class NotificationScreen extends React.Component {
 
     state = {
         notificationExpanded: false,
-        notifications: [{ title: 'Tomat', description: 'Dags att odla tomater!' }],
+        notifications: [{ title: 'Tomat', description: 'Dags att odla tomater!' }, { title: 'Jord', description: 'Asdf!' }],
         notificationMap: [],
         expandedTitle: '',
         expandedDescription: ''
@@ -23,7 +23,7 @@ class NotificationScreen extends React.Component {
         const mapOfNotifications = (this.state.notifications.map(notification =>
             (<NotificationListItem
                 key={notification.title}
-                title={notification.title}
+                notification={notification}
                 pressed={this.openExpandedNotification.bind(this)}
             />)
         ));
@@ -39,14 +39,12 @@ class NotificationScreen extends React.Component {
         return this.state.notificationMap;
     }
 
-    //Opens the expanded notification based on the title of the notification that has been clicked
-    //The key needs to be reworked as it doesn't have to be uniqe right now, which will cause issues
-    openExpandedNotification(title) {
-        const description = this.state.notifications[0].description;
+    //Opens the expanded notification based on the inputted notification
+    openExpandedNotification(notification) {
         this.setState({
             notificationExpanded: true,
-            expandedTitle: title,
-            expandedDescription: description
+            expandedTitle: notification.title,
+            expandedDescription: notification.description
         });
     }
 


### PR DESCRIPTION
The method that expands the notification now takes a notification as a parameter, and uses that notification to populate its fields. Because of this the notification object has to be sent into the notificationListItem which is not ideal.

We should be able to resolve this issue when the database is set up and working, but we don't think it is worth it to spend more time on it now.

//MR & GH